### PR TITLE
Support Github Enterprise

### DIFF
--- a/lib/saddler/reporter/github/client.rb
+++ b/lib/saddler/reporter/github/client.rb
@@ -6,6 +6,10 @@ module Saddler
         # @param repo [Repository] git repository
         def initialize(repo)
           @repo = repo
+
+          Octokit.configure do |c|
+            c.api_endpoint = "#{ENV["GITHUB_HOSTNAME"]}/api/v3/" if ENV["GITHUB_HOSTNAME"]
+          end
         end
 
         # @param sha [String] target commit sha


### PR DESCRIPTION
I'd like to use this reporter on github enterprise, but it can't. So this pull-request allows us to specify the new environment variable `GITHUB_HOSTNAME`.

Usage:
`$ GITHUB_HOSTNAME=http://yourhostname saddler report --require saddler/reporter/github --reporter ...`
