### PR TITLE
Update dependency of `saddler-reporter-support-git`

### DIFF
--- a/saddler-reporter-github.gemspec
+++ b/saddler-reporter-github.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'octokit', '>= 0'
   spec.add_runtime_dependency 'git_diff_parser', '>= 2.0', '< 3.0'
   spec.add_runtime_dependency 'saddler-reporter-support', '>= 0.1', '< 0.2'
-  spec.add_runtime_dependency 'saddler-reporter-support-git', '>= 0.2', '< 0.3'
+  spec.add_runtime_dependency 'saddler-reporter-support-git', '>= 0.2.1', '< 0.3'
 
   spec.add_development_dependency 'bundler', '>= 0'
   spec.add_development_dependency 'rake', '>= 0'


### PR DESCRIPTION
`saddler-reporter-support-git` v0.2.0 cannot parse a git remote url formatted as ssh protocol correctly. for example,  `git@github.com:owner/repo.git` doesn't match `slug_regex`, but you fixed in new version. ( diff: https://github.com/packsaddle/ruby-saddler-reporter-support-git/commit/18a654567ba87edaa794d8c2a441c8588390ca81#diff-5ba67fe95fe6cf972c87119b01693aee
)
