### PR TITLE
Add `reporter-github-log_octokit` option to log octokit request / response

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ like this. See [Saddler](https://github.com/packsaddle/ruby-saddler).
 
 ## Debugging
 
-You can use `reporter-github-log_octokit` option.
+You can use `reporter-github-log_octokit` option to log octokit's requests and responses.
 
 ```
 $ saddler report \

--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ $ saddler report \
 
 like this. See [Saddler](https://github.com/packsaddle/ruby-saddler).
 
+## Debugging
+
+You can use `reporter-github-log_octokit` option.
+
+```
+$ saddler report \
+   --require saddler/reporter/github \
+   --reporter Saddler::Reporter::Github::PullRequestReviewComment \
+   --options 'reporter-github-log_octokit:true'
+```
 
 ## Requirement
 

--- a/lib/saddler/reporter/github/client.rb
+++ b/lib/saddler/reporter/github/client.rb
@@ -4,8 +4,10 @@ module Saddler
       # GitHub client wrapper
       class Client
         # @param repo [Repository] git repository
-        def initialize(repo)
+        # @param log_octokit [Boolean] if true, enable octokit logging
+        def initialize(repo, log_octokit: false)
           @repo = repo
+          @log_octokit = log_octokit
         end
 
         # @param sha [String] target commit sha
@@ -113,7 +115,22 @@ module Saddler
 
         # @return [Octokit::Client]
         def client
-          @client ||= Octokit::Client.new(access_token: access_token)
+          @client ||= if @log_octokit
+                        # see: https://github.com/octokit/octokit.rb/tree/v5.6.1#debugging
+                        middleware = Faraday::RackBuilder.new do |builder|
+                          builder.use Faraday::Retry::Middleware, exceptions: [Octokit::ServerError] # or Faraday::Request::Retry for Faraday < 2.0
+                          builder.use Octokit::Middleware::FollowRedirects
+                          builder.use Octokit::Response::RaiseError
+                          builder.use Octokit::Response::FeedParser
+                          builder.response :logger, nil, { headers: true, bodies: { request: true, response: true } } do |logger|
+                            logger.filter(/(Authorization: "(token|Bearer) )(\w+)/, '\1[REMOVED]')
+                          end
+                          builder.adapter Faraday.default_adapter
+                        end
+                        Octokit::Client.new(access_token: access_token, middleware: middleware)
+                      else
+                        Octokit::Client.new(access_token: access_token)
+                      end
         end
 
         # @return [String, nil] github access token

--- a/lib/saddler/reporter/github/client.rb
+++ b/lib/saddler/reporter/github/client.rb
@@ -118,7 +118,6 @@ module Saddler
           @client ||= if @log_octokit
                         # see: https://github.com/octokit/octokit.rb/tree/v5.6.1#debugging
                         middleware = Faraday::RackBuilder.new do |builder|
-                          builder.use Faraday::Retry::Middleware, exceptions: [Octokit::ServerError] # or Faraday::Request::Retry for Faraday < 2.0
                           builder.use Octokit::Middleware::FollowRedirects
                           builder.use Octokit::Response::RaiseError
                           builder.use Octokit::Response::FeedParser

--- a/lib/saddler/reporter/github/commit_comment.rb
+++ b/lib/saddler/reporter/github/commit_comment.rb
@@ -19,7 +19,7 @@ module Saddler
           sha = options['sha'] || repo.head.sha
           data = parse(messages)
 
-          client = Client.new(repo)
+          client = Client.new(repo, log_octokit: options['reporter-github-log_octokit'])
           # fetch commit_comments
           commit_comments = client.commit_comments(sha)
 

--- a/lib/saddler/reporter/github/commit_review_comment.rb
+++ b/lib/saddler/reporter/github/commit_review_comment.rb
@@ -21,7 +21,7 @@ module Saddler
           sha = options['sha'] || repo.head.sha
           data = parse(messages)
 
-          client = Client.new(repo)
+          client = Client.new(repo, log_octokit: options['reporter-github-log_octokit'])
           # fetch commit_comments
           commit_comments = client.commit_comments(sha)
 

--- a/lib/saddler/reporter/github/pull_request_comment.rb
+++ b/lib/saddler/reporter/github/pull_request_comment.rb
@@ -6,18 +6,18 @@ module Saddler
         include Helper
 
         # @param messages [String] checkstyle string
-        # @param _options [Hash]
+        # @param options [Hash]
         #
         # @return [void]
         #
         # @see https://developer.github.com/v3/issues/comments/#create-a-comment
-        def report(messages, _options)
+        def report(messages, options)
           repo_path = '.'
           repo = Repository.new(repo_path)
 
           data = parse(messages)
 
-          client = Client.new(repo)
+          client = Client.new(repo, log_octokit: options['reporter-github-log_octokit'])
           # fetch pull_request_comments(issue)
           pull_request_comments = client.issue_comments
 

--- a/lib/saddler/reporter/github/pull_request_review_comment.rb
+++ b/lib/saddler/reporter/github/pull_request_review_comment.rb
@@ -6,17 +6,17 @@ module Saddler
         include Helper
 
         # @param messages [String] checkstyle string
-        # @param _options [Hash]
+        # @param options [Hash]
         #
         # @return [void]
         #
         # @see https://developer.github.com/v3/pulls/comments/#create-a-comment
-        def report(messages, _options)
+        def report(messages, options)
           repo_path = '.'
           repo = Repository.new(repo_path)
 
           data = parse(messages)
-          client = Client.new(repo)
+          client = Client.new(repo, log_octokit: options['reporter-github-log_octokit'])
           # fetch pull_request_review_comments
           pull_request_review_comments = client.pull_request_review_comments
 


### PR DESCRIPTION
Maybe related to https://github.com/packsaddle/ruby-saddler-reporter-github/issues/11.

I added the `reporter-github-log_octokit` option, which enables us to inspect octokit's request and response.
With this option, I believe we can debug our CI more easily.

## Usage

See the explanation I added to README

## Example

You can see the log example at https://github.com/genya0407/test-saddler-log-octokit/actions/runs/3213375525/jobs/5252994407