### PR TITLE
Safe empty checkstyle element

### DIFF
--- a/lib/saddler/reporter/github/helper.rb
+++ b/lib/saddler/reporter/github/helper.rb
@@ -10,7 +10,7 @@ module Saddler
         # @return [String] concatenated errors. separated with new line.
         def concat_body(data)
           buffer = []
-          files = data['checkstyle']['file'] ||= []
+          files = data.dig('checkstyle', 'file') || []
           files = [files] if files.is_a?(Hash)
           files.each do |file|
             errors = file['error'] ||= []
@@ -32,7 +32,7 @@ module Saddler
         # @return [Array<Comment>] comment objects
         def build_comments_with_patches(data, patches)
           comments = []
-          files = data['checkstyle']['file'] ||= []
+          files = data.dig('checkstyle', 'file') || []
           files = [files] if files.is_a?(Hash)
           files.each do |file|
             errors = file['error'] ||= []


### PR DESCRIPTION
fix https://github.com/packsaddle/ruby-saddler-reporter-github/issues/52

I use this gem every day. I appreciate it very much.

When using the `--force-exclusion` option of `rubocop`, an empty `checkslyle` element may be output.

I will fix this problem.

```rb
irb(main):033:0> Nori.new(parser: :rexml).parse(File.read('2.xml'))['checkstyle']['file']
=> [{"@name"=>"item1"}, {"@name"=>"item2"}]
irb(main):034:0> Nori.new(parser: :rexml).parse(File.read('1.xml'))['checkstyle']['file']
=> {"@name"=>"item1"}
irb(main):035:0> Nori.new(parser: :rexml).parse(File.read('0.xml'))['checkstyle']['file']
(irb):35:in `<main>': undefined method `[]' for nil:NilClass (NoMethodError)
```

```rb
irb(main):038:0> Nori.new(parser: :rexml).parse(File.read('2.xml')).dig('checkstyle', 'file')
=> [{"@name"=>"item1"}, {"@name"=>"item2"}]
irb(main):039:0> Nori.new(parser: :rexml).parse(File.read('1.xml')).dig('checkstyle', 'file')
=> {"@name"=>"item1"}
irb(main):040:0> Nori.new(parser: :rexml).parse(File.read('0.xml')).dig('checkstyle', 'file')
=> nil
```

```xml
% cat 2.xml
<?xml version='1.0'?>
<checkstyle>
  <file name='item1'/>
  <file name='item2'/>
</checkstyle>
```

```xml
% cat 1.xml
<?xml version='1.0'?>
<checkstyle>
  <file name='item1'/>
</checkstyle>
```

```xml
% cat 0.xml
<?xml version='1.0'?>
<checkstyle/>
```